### PR TITLE
Add `enabled` config option

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -2,4 +2,5 @@ use Mix.Config
 
 config :riemann, :address,
   host: "127.0.0.1",
-  port: 6666
+  port: 6666,
+  enabled: true

--- a/lib/riemann.ex
+++ b/lib/riemann.ex
@@ -14,8 +14,9 @@ defmodule Riemann do
 
     address = Application.get_env(:riemann, :address)
     worker_options = [
-      host: address[:host] || "127.0.0.1",
-      port: address[:port] || 5555
+      host:     address[:host] || "127.0.0.1",
+      port:     address[:port] || 5555,
+      enabled: !(address[:enabled] == false)
     ]
 
     children = [


### PR DESCRIPTION
Hello,

First, thank you for creating and maintaining this project.

I've created a PR to add a new `enabled` config option. The reason to do this, is because in a project I am currently working, we have to avoid connecting to the riemann server and sending messages when the environment is test or dev.

Now, this can be easily achieved but adding a new config option called `enabled` and set it to false. So we can have different configs per env, and only enable `elixir-riemann` in production, but keep using the same code in the other envs.

I hope you like the idea.
