### PR TITLE
Add travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: elixir
+dist: trusty
+
+elixir:
+  - 1.4.2
+
+otp_release:
+  - 19.3
+
+cache:
+  directories:
+    - _build
+    - deps
+
+before_script:
+  - MIX_ENV=test mix compile
+
+script:
+  - mix test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Riemann
+Riemann [![Build Status](https://travis-ci.org/koudelka/elixir-riemann.svg?branch=master)](https://travis-ci.org/koudelka/elixir-riemann)
 =======
 
 Riemann is (surprise!) a [Riemann](http://riemann.io) client for [Elixir](http://elixir-lang.org).


### PR DESCRIPTION
This adds travis ci so we can have automated builds (and a log of historical build output). The badge in the readme is all set up with your username so all you should need to do is go to travis-ci and turn it on. 😅 