### PR TITLE
Test against Elixir 1.4.5, 1.5.1 and OTP 18-20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,13 @@ language: elixir
 dist: trusty
 
 elixir:
-  - 1.4.2
+  - 1.4.5
+  - 1.5.1
 
 otp_release:
+  - 18.0
   - 19.3
+  - 20.0
 
 cache:
   directories:

--- a/mix.lock
+++ b/mix.lock
@@ -3,4 +3,4 @@
   "exprotobuf": {:hex, :exprotobuf, "1.2.7", "287e2a1239fa9924c71815b1961e6e97d55c13496e9feb4ad755706af105ec36", [:mix], [{:gpb, "~> 3.24", [hex: :gpb, repo: "hexpm", optional: false]}], "hexpm"},
   "gen_stage": {:hex, :gen_stage, "0.10.0", "ce1eb93a3f9708f2e215f70b3d3c7f55dea4a4ed7e9615195e28d543c9086656", [:mix], []},
   "gpb": {:hex, :gpb, "3.27.2", "6053d63f10a0e6f2258143b8754172a2ed053e7e7eddbe880aa15d1ad4f5ba33", [:make, :rebar], [], "hexpm"},
-  "honeydew": {:hex, :honeydew, "1.0.0", "e2d8e0c32889379581cf40af2a7c379452ffdc7c19c153a942921224c7b8b44b", [:mix], [], "hexpm"}}
+  "honeydew": {:hex, :honeydew, "1.0.1", "7266286ffcedab64ebcfe740307d8bea941558a35415ae1fa22fcfe84adaf6d6", [:mix], [], "hexpm"}}


### PR DESCRIPTION
This runs the test suite against Elixir 1.4.5, 1.5.1 and OTP 18.0,19.3 and 20.0. It also upgrades honeydew to the latest release which now supports down to OTP 18.0.